### PR TITLE
Make library import its functions

### DIFF
--- a/sensopy/__init__.py
+++ b/sensopy/__init__.py
@@ -1,3 +1,4 @@
+from discrim import *
 
 __author__ = "Edgar Ramirez Mondragon"
 __copyright__ = None


### PR DESCRIPTION
You were missing a key line that prevented your library from being useable. I've added it. Now after doing `pip install sensopy` a user can actually access your functions!